### PR TITLE
Initial support for tags (> Graphite 1.1.1)

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -17,6 +17,7 @@ func init() {
 	RootCmd.Flags().IntP("batch", "b", 10000, "batch count per file")
 	RootCmd.Flags().IntP("timeout", "t", 5, "batch timeout for flushing datapoints")
 	RootCmd.Flags().StringP("directory", "d", "./sources", "directory to write metrics file")
+	RootCmd.Flags().BoolP("parse", "p", true, "parse metric name to auto fill tags")
 
 	viper.BindPFlags(RootCmd.Flags())
 	viper.BindPFlags(RootCmd.PersistentFlags())
@@ -68,7 +69,7 @@ var RootCmd = &cobra.Command{
 
 		wr := writer.NewWriter(viper.GetString("directory"))
 
-		graphite := listener.NewGraphite(viper.GetString("listen"), wr)
+		graphite := listener.NewGraphite(viper.GetString("listen"), wr, viper.GetBool("parse"))
 		err := graphite.OpenTCPServer()
 		if err != nil {
 			panic(err)

--- a/config/config.json
+++ b/config/config.json
@@ -3,5 +3,6 @@
   "verbose": "false",
   "batch": "10000",
   "timeout": "5",
+  "parse": "false",
 }
 


### PR DESCRIPTION
This PR 

- adds support for Carbon tags
- adds the ability to control the parsing over the keys that auto fill tags through Graphite ingestion.

Given the following series : 
`os.cpu;host=srv1;dc=rbx 50 1524505745`

Labels will now be parsed and mapped as follow : 
`1524505745000000// os.cpu{host=srv1,dc=rbx} 50`


Given the following series : 
`os.cpu 50 1524505745`

Labels can be parsed or not and mapped as follow : 
  w/ auto fill : `1524505745000000// os.cpu{0=os,1=cpu} 50`
w/o auto fill : `1524505745000000// os.cpu{} 50`
